### PR TITLE
🔨fix: build fails on windows.

### DIFF
--- a/packages/footer/package.json
+++ b/packages/footer/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "main": "dist/index.js",
   "scripts": {
-    "build": "rm -rf dist && rollup --config",
+    "build": "rimraf dist && rollup --config",
     "test": "jest"
   },
   "dependencies": {
@@ -18,5 +18,8 @@
     "ts-jest": "^27.1.1",
     "tslib": "^2.3.1",
     "typescript": "^4.5.2"
+  },
+  "devDependencies": {
+    "rimraf": "^3.0.2"
   }
 }

--- a/packages/header/package.json
+++ b/packages/header/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "main": "dist/index.js",
   "scripts": {
-    "build": "rm -rf dist && rollup --config",
+    "build": "rimraf dist && rollup --config",
     "test": "jest"
   },
   "dependencies": {
@@ -18,5 +18,8 @@
     "ts-jest": "^27.1.1",
     "tslib": "^2.3.1",
     "typescript": "^4.5.2"
+  },
+  "devDependencies": {
+    "rimraf": "^3.0.2"
   }
 }


### PR DESCRIPTION
This commit uses rimraf instead of rm to remove previous builds.