### PR TITLE
fix: emit types for react components from packages folder

### DIFF
--- a/packages/footer/package.json
+++ b/packages/footer/package.json
@@ -2,6 +2,7 @@
   "name": "footer",
   "version": "0.0.0",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "rimraf dist && rollup --config",
     "test": "jest"

--- a/packages/footer/tsconfig.json
+++ b/packages/footer/tsconfig.json
@@ -3,7 +3,9 @@
     "jsx": "react",
     "allowJs": true,
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "outDir": "./dist",
+    "declaration": true
   },
   "files": [],
   "include": [],

--- a/packages/header/package.json
+++ b/packages/header/package.json
@@ -2,6 +2,7 @@
   "name": "header",
   "version": "0.0.0",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "rimraf dist && rollup --config",
     "test": "jest"

--- a/packages/header/tsconfig.json
+++ b/packages/header/tsconfig.json
@@ -3,7 +3,9 @@
     "jsx": "react",
     "allowJs": true,
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "outDir": "./dist",
+    "declaration": true
   },
   "files": [],
   "include": [],


### PR DESCRIPTION
With those changes you should now have types for your react components from `packages`

Previously there was a TS error and no types were emitted:

![image](https://user-images.githubusercontent.com/16666234/212869491-053fb9f2-599e-46b8-8e1f-cac40f2250e6.png)

After this change, the types should be emitted:

![image](https://user-images.githubusercontent.com/16666234/212869930-903b4edf-7a8d-4060-8dd6-6ad4cc049e71.png)
