### PR TITLE
chore: add workspaces property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "name": "root",
   "private": true,
-  "devDependencies": {
-  }
+  "workspaces": [
+    "packages/*"
+  ],
+  "devDependencies": {}
 }


### PR DESCRIPTION
Add workspaces property to package.json, as it is required for `npx lerna@latest init`. Alternatively, the user can specify `--packages` as described the getting started docs: https://lerna.js.org/docs/getting-started#adding-lerna-to-an-existing-repo.